### PR TITLE
Add auto oauth token refresh for GETs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+AWS_ACCESS_KEY_ID=[snip]
+AWS_SECRET_ACCESS_KEY=[snip]
+NYPL_API_BASE_URL=[https://url-to-our-playform.example.com/api/v0.1/]
+LOG_LEVEL=error
+NYPL_OAUTH_KEY=[an-oauth-key]
+NYPL_OAUTH_URL=[https://our-internal-sso.server.org/]
+NYPL_OAUTH_SECRET=[snip]

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ nypl-data-api schema post [name] [jsonfile]
 
 ## Testing
 
+1.  Pull this repository
+1.  Copy `./.env.example` to `./.env` and plug in values
 ```js
 npm test
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Params:
  - **opts**: Optional options hash that may include:
    - **cache**: Boolean, default `true`. Controls whether or not response is cached (using default configuration of [node-cache](https://www.npmjs.com/package/node-cache)
    - **authenticate**: Boolean, default `true`. Controls whether or not to OAUTH first.
+   - **token_expiration_retries**: Int, default 1. Controls how many times the client will attempt to fetch a new OAUTH token if cached token seems to have expired.
 
 To authenticate and fetch a bib (all GETs authenticate first, by default):
 ```js

--- a/lib/client.js
+++ b/lib/client.js
@@ -30,7 +30,7 @@ class Client {
     opts = Object.assign({
       cache: true,
       authenticate: true,
-      token_expiration_retries: 2 // Number of refresh attempts to make if token expired (1 should do it!)
+      token_expiration_retries: 1 // Number of refresh attempts to make if token expired (1 should do it!)
     }, opts)
 
     var uri = this._getFullUrl(path)

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,6 +5,9 @@ const NodeCache = require('node-cache')
 const log = require('loglevel').getLogger('nypl-data-api-client')
 const OAuth = require('oauth')
 
+const TokenExpirationError = require('./errors').TokenExpirationError
+const TokenRefreshError = require('./errors').TokenRefreshError
+
 class Client {
 
   constructor (opts) {
@@ -26,7 +29,8 @@ class Client {
     opts = opts || {}
     opts = Object.assign({
       cache: true,
-      authenticate: true
+      authenticate: true,
+      token_expiration_retries: 2 // Number of refresh attempts to make if token expired (1 should do it!)
     }, opts)
 
     var uri = this._getFullUrl(path)
@@ -44,6 +48,10 @@ class Client {
       if (opts.authenticate) {
         return this.token()
           .then((token) => this._doGet(uri, { headers: { Authorization: `Bearer ${token}` } }))
+          .catch((error) => {
+            return this._refreshTokenIfExpired(error, opts)
+              .then((newOptions) => this.get(path, newOptions))
+          })
           .then(handleCache)
       } else {
         return this._doGet(uri)
@@ -107,6 +115,12 @@ class Client {
     })
   }
 
+  refreshToken () {
+    this.access_token = null
+
+    return this.token()
+  }
+
   _doGet (url, options) {
     options = options || {}
     options = Object.assign({
@@ -122,9 +136,19 @@ class Client {
 
       log.info('GET: ' + requestOptions.uri)
       request(requestOptions, (error, resp, body) => {
+        // Handle low level, non-http error:
         if (error) reject(error)
-        else if (!body || !body.data) reject('Invalid response: for ' + url, body)
-        else {
+
+        // Handle token expiration:
+        else if (body && body.statusCode === 401) {
+          reject(new TokenExpirationError('Detected token expiration fetching ' + url))
+
+        // Sanity check response, trigger error if empty:
+        } else if (!body || !body.data) {
+          reject('Invalid response: for ' + url + ': ' + JSON.stringify(body))
+
+        // Response looks good; resolve it:
+        } else {
           log.debug('GET: ' + requestOptions.uri + ': ', body)
           var data = body.data
           resolve(data)
@@ -138,6 +162,25 @@ class Client {
     if (!baseUrl) throw new Error('NYPL api base url not set (may be set in config.base_url or ENV[NYPL_API_BASE_URL]')
 
     return baseUrl + path
+  }
+
+  /**
+   *  Examines an error thrown by _doGet to either attempt token refresh or throw an error in defeat.
+   *  TODO Presently only used by `get`. Should be integrated with `post` to resolve token expirations during POSTs
+   *
+   *  @return {Object} hash with updated options array suitable for sending into `get`
+   */
+  _refreshTokenIfExpired (error, options) {
+    if (error && error.name === 'TokenExpirationError') {
+      let retriesRemaining = options.token_expiration_retries
+      if (retriesRemaining > 0) {
+        log.debug('Expired OAUTH token detected, ' + options.token_expiration_retries + ' retries remaining')
+        let newOptions = Object.assign({}, options, { token_expiration_retries: retriesRemaining - 1 })
+        return this.refreshToken().then(() => newOptions)
+      } else {
+        throw new TokenRefreshError('Exhausted retries refreshing token')
+      }
+    } else throw error
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -147,7 +147,7 @@ class Client {
         if (error) reject(error)
 
         // Handle token expiration:
-        else if (body && body.statusCode === 401) {
+        else if (resp && resp.statusCode === 401) {
           reject(new TokenExpirationError('Detected token expiration fetching ' + url))
 
         // Sanity check response, trigger error if empty:

--- a/lib/client.js
+++ b/lib/client.js
@@ -49,6 +49,8 @@ class Client {
         return this.token()
           .then((token) => this._doGet(uri, { headers: { Authorization: `Bearer ${token}` } }))
           .catch((error) => {
+            // Let `_refreshTokenIfExpired` check the error to determine whether
+            // or not to attempt a token refresh and retry:
             return this._refreshTokenIfExpired(error, opts)
               .then((newOptions) => this.get(path, newOptions))
           })
@@ -115,6 +117,11 @@ class Client {
     })
   }
 
+  /**
+   * Declares current token invalid, attempts token refresh
+   *
+   * @return {Promise} resoves a new token
+   */
   refreshToken () {
     this.access_token = null
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,18 @@
+// Thrown internally when response indicates OAUTH token expired:
+class TokenExpirationError extends Error {
+  constructor (message) {
+    super()
+    this.name = 'TokenExpirationError'
+    this.message = message
+  }
+}
+
+// Thrown externally when token refresh fails
+class TokenRefreshError extends Error {
+  constructor (message) {
+    super()
+    this.name = 'TokenRefreshError'
+    this.message = message
+  }
+}
+module.exports = { TokenExpirationError, TokenRefreshError }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple client for interacting with NYPL's internal data api",
   "main": "index.js",
   "scripts": {
-    "test": "standard && mocha"
+    "test": "./node_modules/.bin/standard && ./node_modules/.bin/mocha"
   },
   "author": "@nonword",
   "license": "ISC",
@@ -21,7 +21,8 @@
     "request": "^2.81.0"
   },
   "devDependencies": {
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "standard": "^6.0.8"
   },
   "directories": {
     "test": "test"

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,1 @@
+require('dotenv').config()

--- a/test/oauth-test.js
+++ b/test/oauth-test.js
@@ -1,0 +1,60 @@
+/* global describe it */
+
+const assert = require('assert')
+const Client = require('../index')
+
+describe('OAUTH', function () {
+  this.timeout(10000)
+
+  describe('token expiration', function () {
+    it('should trigger token refresh', function () {
+      var client = new Client()
+
+      // Do something that triggers token fetch:
+      return client.get('bibs?limit=1&offset=0', { authenticate: true })
+        .then((res) => {
+          assert(res)
+
+          // Emulate token expiration by making it invalid:
+          client.access_token = 'gobbledeesplat'
+          return client.get('bibs?limit=1&offset=1', { authenticate: true }).then((res) => {
+            assert(res)
+          })
+        })
+    })
+
+    it('should attempt to refresh token only N times after first failure', function () {
+      var client = new Client()
+
+      // Do something that triggers token fetch:
+      return client.get('bibs?limit=1&offset=0', { authenticate: true })
+        .then((res) => {
+          // This one should succeed because we haven't monkeyed with the token yet:
+          assert(res)
+
+          // Emulate token expiration by making it invalid:
+          client.access_token = 'gobbledeesplat'
+
+          // Emulate repeated token refresh failure by hijacking refreshToken:
+          let refreshCalled = 0
+          client.refreshToken = () => {
+            // Count the number of times the client attempts to refresh the token IN VAIN
+            refreshCalled += 1
+            return Promise.resolve()
+          }
+
+          // We'll let it attempt to refresh the token 3 times in sequence
+          // Each time it will fail because we've replaced the refreshToken method with utter nonsense
+          return client.get('bibs?limit=1&offset=1', { authenticate: true, token_expiration_retries: 3 }).then((res) => {
+            // Arriving here is a failure because we passed an invalid token
+            assert(false)
+          }).catch((error) => {
+            // When client exhauses retries, this error is thrown:
+            assert.equal(error.name, 'TokenRefreshError')
+            // Confirm it retried exactly options.token_expiration_retries times:
+            assert.equal(refreshCalled, 3)
+          })
+        })
+    })
+  })
+})


### PR DESCRIPTION
This PR ensures that calling `client.get` on an authenticated URL will attempt to refresh the cached OAUTH token if the response indicates the token has expired (i.e. status code 401). This means clients instantiated by long-running processes (e.g. frozen lambdas) that send very old access tokens will detect the expiration, attempt to refresh the token, and try the request again. The number of recursive refreshes allowed is configurable, defaulting to 1 - mainly to avoid infinite recursion. A new test file demonstrates successful token refresh by forcing token invalidation.