### PR TITLE
Small bug fix to return data where endpoints don't wrap it in a data prop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# CHANGELOG
+
+### 0.2.4
+- Small bug fix to return data from a GET if the endpoint does not wrap the data object in a `data` property.

--- a/lib/client.js
+++ b/lib/client.js
@@ -151,13 +151,13 @@ class Client {
           reject(new TokenExpirationError('Detected token expiration fetching ' + url))
 
         // Sanity check response, trigger error if empty:
-        } else if (!body || !body.data) {
+        } else if (!body) {
           reject('Invalid response: for ' + url + ': ' + JSON.stringify(body))
 
         // Response looks good; resolve it:
         } else {
           log.debug('GET: ' + requestOptions.uri + ': ', body)
-          var data = body.data
+          var data = body.data ? body.data : body
           resolve(data)
         }
       })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/nypl-data-api-client",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Simple client for interacting with NYPL's internal data api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #2 . I tested this in the front-end which hits the `/hold-request`, `/discovery/resources`, and `request/deliveryLocationsByBarcode` endpoints and it seems to work.