### PR TITLE
Add headers to POST method and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,15 @@ client.get('patrons/12345678').then((patron) => {
 ```
 
 
-### client.post (path, data)
+### client.post (path, data, headers)
 
 Returns a Promise that resolves after submitting `data` to `path`
 
 Params:
  - **path**: String path to retrieve
  - **data**: Object/data you want to POST to the endpoint
+ - **headers**: Object representing headers to send to the endpoint. 
+   By default, the `Authorization` and `Content-type: application/json` headers are added.
 
 For example, to post a new "TestSchema" schema:
 ```js

--- a/lib/client.js
+++ b/lib/client.js
@@ -62,9 +62,15 @@ class Client {
     }
   }
 
-  post (path, body) {
+  post (path, body, headers) {
     return this.token().then((token) => {
-      var headers = { Authorization: `Bearer ${token}` }
+      headers = Object.assign(
+        {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/json'
+        },
+        headers
+      )
       var uri = this._getFullUrl(path)
       var options = { method: 'POST', headers, uri, body }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/nypl-data-api-client",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Simple client for interacting with NYPL's internal data api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds the `Content-type: application/json` header by default to POST requests as well as an optional `headers` object that can be passed to the method.

This is important so that services properly know how to decode POST requests. This will hopefully solve an issue we've seen where a service's request body is decoded to `null`.