### PR TITLE
Improvements related to schema posting, patching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+install: npm install
+script: npm test

--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ To get help with any command run:
 nypl-data-api help [command]
 ```
 
-Note that the lib draws from the following environment variables, which you can place in `.env`:
+Note that the cli uses the following environment variables, read by default from `.env`:
 
  - NYPL_API_BASE_URL
  - NYPL_OAUTH_KEY
  - NYPL_OAUTH_SECRET
  - NYPL_OAUTH_URL
+
+See `.env.example` for a sample `.env` file. To specify a different `.env`, use the `--envfile` param (e.g. `--envfile config/qa.env`)
 
 ### Schema post
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -90,6 +90,24 @@ class Client {
   }
 
   /**
+   * PATCH a resource at an api endpoint
+   *
+   * @param {string} path - The path to fetch (e.g. 'current-schema/Item')
+   * @param {Object} body - The partial object to pass with the request
+   * @param {RequestOptions} options - A hash of options.
+   *
+   * @return {Promise} A promise that resolves the result data
+   */
+  patch (path, body, options = {}) {
+    options = Object.assign({
+      body
+    }, options)
+
+    log.debug(`patch("${path}", ${JSON.stringify(body)} (${typeof body}),  ${JSON.stringify(options)})`)
+    return this._doHttpMethod('PATCH', path, options)
+  }
+
+  /**
    * DELETE an object from an api endpoint
    *
    * @param {string} path - The path to fetch (e.g. 'current-schema/Item')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/nypl-data-api-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/data/hold-requests%2F1234-patch.json
+++ b/test/data/hold-requests%2F1234-patch.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "id": 1234,
+    "jobId": "1106896193cb7216d96",
+    "createdDate": "2021-11-16T10:17:06-05:00",
+    "updatedDate": "2021-11-16T10:17:12-05:00",
+    "success": false,
+    "processed": true,
+    "patron": "987654321",
+    "nyplSource": "sierra-nypl",
+    "requestType": "hold",
+    "recordType": "i",
+    "record": "15371503",
+    "pickupLocation": "",
+    "deliveryLocation": "NH",
+    "neededBy": "2022-11-16T00:00:00-05:00",
+    "numberOfCopies": 1,
+    "docDeliveryData": null,
+    "error": null
+  },
+  "count": 1,
+  "statusCode": 200,
+  "debugInfo": []
+}

--- a/test/patch-test.js
+++ b/test/patch-test.js
@@ -1,0 +1,54 @@
+let client = null
+
+describe('Client PATCH method', function () {
+  beforeEach(() => {
+    client = require('./make-test-client')()
+  })
+
+  afterEach(() => {
+    client = null
+  })
+
+  // This is a common patch that the
+  // [HoldRequestResultConsumer makes](https://github.com/NYPL/hold-request-result-consumer/blob/e7bd5b04afe25cf65ed2a5ce2de0576973e592cb/src/OAuthClient/HoldRequestClient.php#L123)
+  // makes when it detects a hold-request has been fulfilled
+  var holdRequestPatch = {
+    success: true,
+    processed: true
+  }
+
+  describe('when config.json=true (default)', function () {
+    it('should accept a new schema object via PATCH and return an object', function () {
+      return client.patch('hold-requests/1234', holdRequestPatch)
+        .then((resp) => {
+          expect(resp).to.be.a('object')
+        })
+    })
+
+    it('should fail if supplied body is plaintext', function () {
+      let call = client.patch('hold-requests/1234', JSON.stringify(holdRequestPatch))
+      return expect(call).to.be.rejected
+    })
+
+    // A null/empty body should be accepted as valid if options.json===true
+    it('should succeed if supplied body is empty', function () {
+      let call = client.patch('hold-requests/1234')
+      return expect(call).to.be.fulfilled
+    })
+  })
+
+  describe('when config.json=false', function () {
+    it('should accept a plaintext body and return plain text', function () {
+      let call = client.patch('hold-requests/1234', JSON.stringify(holdRequestPatch), { json: false })
+      return Promise.all([
+        expect(call).to.be.fulfilled,
+        expect(call).to.eventually.be.a('string')
+      ])
+    })
+
+    it('should fail if supplied body is not plaintext', function () {
+      let call = client.patch('hold-requests/1234', holdRequestPatch, { json: false })
+      return expect(call).to.be.rejected
+    })
+  })
+})


### PR DESCRIPTION
Improves several things:
 - Adds support for PATCH
 - Improves schema-post CLI util
 - Improves documentation around authentication
 - Add tests for PATCH requests 

This is essentially cleanup work on the CLI, which will help updating Avro schemas (e.g. https://jira.nypl.org/browse/SCC-2933 )